### PR TITLE
Fix for #2, otp can return null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# for node_modules folder
+node_modules

--- a/controllers/otp.js
+++ b/controllers/otp.js
@@ -29,6 +29,9 @@ exports.save = (email,code,cb)=>
 			.exec((err,data)=>{
 				if(err)
 					cb(err);
+				if(data==undefined) {
+					return console.log("undefined: otp.create -191")
+				}
 				cb(null,data);
 			});
 		}
@@ -40,9 +43,13 @@ exports.match = (email,code,cb)=>
 	otp.find({email: email})
 	.exec((err,data)=>{
 		if(err)
-			cb(err);
-		if(data.length==0)
-			cb(null,undefined);			
+			cb(err);	
+		if(data==null){
+				return console.log("null: otp.match -193")
+		}
+		if(data==undefined){
+				return console.log("undefined: otp.match -192")
+		}
 		else
 			cb(null,bcrypt.match(code,data[0].code));
 	});
@@ -54,6 +61,9 @@ exports.remove = (email,cb)=>
 	.exec((err,data)=>{
 		if(err)
 			cb(err);
+		if(data==null){
+			return console.log("null: otp.remove -193")
+		}
 		cb(null,data);
 	})
 }

--- a/controllers/otp.js
+++ b/controllers/otp.js
@@ -32,7 +32,10 @@ exports.save = (email,code,cb)=>
 				if(data==undefined) {
 					return console.log("undefined: otp.create -191")
 				}
-				cb(null,data);
+				if(!data==undefined){
+					cb(null,data);
+
+				}
 			});
 		}
 	});
@@ -64,6 +67,9 @@ exports.remove = (email,cb)=>
 		if(data==null){
 			return console.log("null: otp.remove -193")
 		}
-		cb(null,data);
+		if(!data==null) {
+			cb(null,data);
+
+		}
 	})
 }

--- a/server.js
+++ b/server.js
@@ -80,6 +80,8 @@ app.locals.image = null;
 app.locals.count = counter;
 app.locals.uri = null;
 
+
+
 app.get("/", (req, res) => {
     counter++;
     res.locals.url = req.protocol + '://' + req.get('host') + req.originalUrl;


### PR DESCRIPTION
This update to OTP checks if the values in `.create()` `.remove()` `.match()` are null or undefined. 

Without this patch a possible entry point with NULL based injection, as seen here: https://cwe.mitre.org/data/definitions/158.html

and can be used to access certain parts of the web app, such as the database. 

This patch removes all NULL based entry points in OTP. 

(patch #1 v1.0.1)
